### PR TITLE
checkout git repo to subdirectory in workspace

### DIFF
--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -154,6 +154,9 @@ class JobHelper {
         }
         branch(buildBranch)
         wipeOutWorkspace()
+        if (vars.containsKey('subdirectory')) {
+          relativeTargetDir(vars.get('subdirectory'))
+        }
       }
     }
   }


### PR DESCRIPTION
Ability to checkout a repo to a sub directory in a workspace by specifying a "subdirectory:" parameter in the job. see example bellow...

```
jobs:
  -
    name: Build-App
    folder: default
    repo: repo/myapp
    branch: master
    subdirectory: myapp
    parameters:
      application: myapp
    shell:
      - file: scripts/build-myapp.sh
    archive:
      - ${APPLICATION}-${BUILD_NUMBER}.tar.gz
```
