### PR TITLE
Feature/discardoldbuilds

### DIFF
--- a/ciinaboxes.example/example/jenkins/jobs.yml
+++ b/ciinaboxes.example/example/jenkins/jobs.yml
@@ -152,3 +152,13 @@ jobs:
         - check
       switches:
         - "--info"
+  -
+    name: Example-Create-Secrets
+    folder: example
+    discardBuilds:
+      buildsToKeep: 1
+      daysToKeep: 1
+      artifactBuildsToKeep: 1
+      artifactDaysToKeep: 1
+    shell:
+      - file: create-secrets.sh

--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -7,6 +7,7 @@ class JobHelper {
   static void defaults(def job, def vars) {
     description(job, vars.get('description',vars.get('jobName','')))
     labels(job, vars.get('labels', []))
+    discardBuilds(job, vars)
     parameters(job,vars.get('parameters',[:]))
     scm(job,vars)
     copyLatestSuccessfulArtifacts(job, vars.get('artifacts',[]), vars.get('jobNames',[]))
@@ -393,6 +394,22 @@ class JobHelper {
 
   static void description(def job, def desc) {
     job.description(desc)
+  }
+
+  static void discardBuilds(def job, def vars) {
+    if (vars.containsKey('discardBuilds')) {
+      def parameters = vars.get('discardBuilds')
+      def builds = (parameters.containsKey('buildsToKeep') ? parameters.get('buildsToKeep') : -1 )
+      def days = (parameters.containsKey('daysToKeep') ? parameters.get('daysToKeep') : -1 )
+      def artifactBuilds = (parameters.containsKey('artifactBuildsToKeep') ? parameters.get('artifactBuildsToKeep') : -1 )
+      def artifactDays = (parameters.containsKey('artifactDaysToKeep') ? parameters.get('artifactDaysToKeep') : -1 )
+      job.logRotator {
+        numToKeep(builds)
+        daysToKeep(days)
+        artifactNumToKeep(artifactBuilds)
+        artifactDaysToKeep(artifactDays)
+      }
+    }
   }
 
   private static boolean isCollectionOrArray(object) {


### PR DESCRIPTION
Enables "Discard old builds -> LogRotation" for a job.

Defined by the following yml
```
-
  name: example-job
  discardBuilds:
    buildsToKeep: 1
    daysToKeep: 2
    artifactBuildsToKeep: 3
    artifactDaysToKeep: 4
```

If `discardBuilds` is not defined, the function will be skipped. 
If `discardBuilds` is defined but no parameters are then the default of -1 (value not set) is used.
if `discardBuilds` is defined and one or more parameters are set, the vale of the set parameter is used and the default -1 value is used for the undefined parameters. 