### PR TITLE
allow jobs to be triggered with cron schedule

### DIFF
--- a/ciinaboxes.example/example/jenkins/jobs.yml
+++ b/ciinaboxes.example/example/jenkins/jobs.yml
@@ -162,3 +162,9 @@ jobs:
       artifactDaysToKeep: 1
     shell:
       - file: create-secrets.sh
+  -
+    name: Example-trigger-job-with-cron
+    folder: conctr
+    cronTrigger: "0 8 * * *"
+    shell:
+      - file: start-environment.sh

--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -9,6 +9,7 @@ class JobHelper {
     labels(job, vars.get('labels', []))
     discardBuilds(job, vars)
     parameters(job,vars.get('parameters',[:]))
+    cronTrigger(job,vars)
     scm(job,vars)
     copyLatestSuccessfulArtifacts(job, vars.get('artifacts',[]), vars.get('jobNames',[]))
     buildEnvironment(job, vars.get('build_environment', [:]), vars)
@@ -408,6 +409,14 @@ class JobHelper {
         daysToKeep(days)
         artifactNumToKeep(artifactBuilds)
         artifactDaysToKeep(artifactDays)
+      }
+    }
+  }
+
+  static void cronTrigger(def job, def vars) {
+    if(vars.containsKey('cronTrigger')) {
+      job.triggers {
+        cron(vars.get('cronTrigger'))
       }
     }
   }


### PR DESCRIPTION
Selects Build periodically in Build Triggers and adds the cron schedule

![screen shot 2016-11-03 at 8 34 48 pm](https://cloud.githubusercontent.com/assets/12812004/19961165/2473bf82-a205-11e6-8968-b8dd1d3f61bf.png)

Uses the following yml
```yml
    name: Example-trigger-job-with-cron
    folder: example
    cronTrigger: "0 20 * * *"
    shell:
      - file: start-environment.sh
```