### PR TITLE
bitbucket improvements

### DIFF
--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -248,11 +248,17 @@ class JobHelper {
 
   static void bitbucket(def job, def scm, def vars) {
     def block = mergeWithDefaults(scm, vars, 'bitbucket')
+    def protocol = (block.get('protocol') == 'ssh' ? 'git@bitbucket.org:' : 'https://bitbucket.org/' )
+    if(block.get('push',false)) {
+      job.triggers{
+        bitbucketPush()
+      }
+    }
     job.scm {
       git {
         remote {
           credentials(block.get('credentials'))
-          url("https://bitbucket.org/${block.get('repo')}.git")
+          url("${protocol}${block.get('repo')}.git")
         }
         branch(block.get('branch'))
         wipeOutWorkspace()


### PR DESCRIPTION
Allow use of ssh urls for bit bucket by specifying `protocol: ssh` in the bitbucket block
Allow use of web hooks from bitbucket by specifying `push: true` in the bitbucket block

```
jobs:
  -
    name: bitbucket
    folder: test
    bitbucket:
      repo: guslington/ciinabox
      protocol: ssh
      branch: develop
      push: true
      repo_target_dir: repo
```

Adding a webhook to bitbucket repo
![screen shot 2016-11-10 at 11 50 57 am](https://cloud.githubusercontent.com/assets/12812004/20160571/0cad785c-a73c-11e6-86ae-cd484001912e.png)
