### PR TITLE
Bug fix: Parse -jobfile switch properly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compile 'org.codehaus.groovy:groovy:2.1.3'
     compile 'org.jenkins-ci.plugins:job-dsl-core:1.41'
     compile 'org.jenkins-ci.plugins:job-dsl:1.41'
-
+    compile group: 'org.apache.commons', name: 'commons-io', version: '1.3.2'
     testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
         exclude module: 'groovy-all'
     }

--- a/src/main/groovy/com/base2/ciinabox/JobSeeder.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobSeeder.groovy
@@ -1,13 +1,15 @@
 package com.base2.ciinabox
 
-import javaposse.jobdsl.dsl.DslScriptLoader
-import org.apache.commons.lang.StringUtils
-import org.yaml.snakeyaml.DumperOptions
-import org.yaml.snakeyaml.Yaml
 import com.base2.rest.RestApiJobManagement
+import javaposse.jobdsl.dsl.DslScriptLoader
+import org.apache.commons.io.FilenameUtils
+import org.apache.commons.lang.StringUtils
+import org.yaml.snakeyaml.Yaml
+
+import java.nio.file.Paths
 
 String ciinabox = System.getProperty('ciinabox')
-String ciinaboxes = System.getProperty('ciinaboxes','ciinaboxes')
+String ciinaboxes = System.getProperty('ciinaboxes', 'ciinaboxes')
 String username = System.getProperty('username')
 String password = System.getProperty('password') // password or token
 String jobFileToProcess = System.getProperty('jobfile')
@@ -15,35 +17,43 @@ String jobToProcess = System.getProperty('job')
 String jenkinsOverrideUrl = System.getProperty('url')
 
 baseDir = new File(".").absolutePath
-baseDir = baseDir.substring(0, baseDir.length()-2)
+baseDir = baseDir.substring(0, baseDir.length() - 2)
 ciinaboxesDir = new File(ciinaboxes)
 
 if (!ciinabox) {
-    println 'usage: -Dciinabox=<ciinabox_name> [-Dciinaboxes=<ciinaboxes dir>] [-Durl=<jenkins_url>] [-Dusername=<username>] [-Dpassword=<password>] [-Djobfile=myjobs.yml]'
-    System.exit 1
+  println 'usage: -Dciinabox=<ciinabox_name> [-Dciinaboxes=<ciinaboxes dir>] [-Durl=<jenkins_url>] [-Dusername=<username>] [-Dpassword=<password>] [-Djobfile=myjobs.yml]'
+  System.exit 1
 }
 
 def yaml = new Yaml()
 def processedJobs = false
-new FileNameFinder().getFileNames("${ciinaboxesDir.absolutePath}/${ciinabox}/jenkins/", "*jobs.yml").each { String jobsFile ->
-  if(jobFileToProcess == null || jobsFile.contains(jobFileToProcess)) {
+new FileNameFinder().getFileNames("${ciinaboxesDir.absolutePath}/${ciinabox}/jenkins/", "*jobs.yml").each {String jobsFile ->
+
+  def matchingByJobfile =
+          jobFileToProcess != null &&
+                  (jobFileToProcess.equalsIgnoreCase(Paths.get(jobsFile).fileName.toString())
+                          || jobFileToProcess.equalsIgnoreCase(FilenameUtils.removeExtension(Paths.get(jobsFile).fileName.toString())))
+
+
+  if (jobFileToProcess == null || matchingByJobfile) {
     def jobs = (Map) yaml.load(new File(jobsFile).text)
     println "\nLoading jobs from file: $jobsFile"
-    if(jenkinsOverrideUrl != null) {
+    if (jenkinsOverrideUrl != null) {
       jobs['jenkins_url'] = jenkinsOverrideUrl
     }
 
     //if specific job is defined
-    if(jobs['jobs'] && StringUtils.isNotEmpty(jobToProcess)){
+    if (jobs['jobs'] && StringUtils.isNotEmpty(jobToProcess)) {
       jobs['jobs'] = jobs['jobs'].findAll {
-          (it['name']==null) || (it['name'].equalsIgnoreCase(jobToProcess)) }
+        (it['name'] == null) || (it['name'].equalsIgnoreCase(jobToProcess))
+      }
     }
 
     manageJobs(baseDir, username, password, jobs)
     processedJobs = true
   }
 }
-if(!processedJobs) {
+if (!processedJobs) {
   j = jobFileToProcess ?: 'jobs.yml'
   println "no ${j} file found for ${ciinabox} found in ${ciinaboxesDir.absolutePath}/jenkins"
 }
@@ -52,27 +62,29 @@ def manageJobs(def baseDir, def username, def password, def jobs) {
 
   RestApiJobManagement jm = new RestApiJobManagement(jobs['jenkins_url'])
   if (username && password) {
-      jm.setCredentials username, password
+    jm.setCredentials username, password
   }
   def jobNames = []
-  jobs['jobs'].each { job ->
-    jobNames << job.get('folder','') + '/' + job.get('name')
+  jobs['jobs'].each {job ->
+    jobNames << job.get('folder', '') + '/' + job.get('name')
   }
-  jobs['jobs'].each { job ->
+  jobs['jobs'].each {job ->
     jm.parameters.clear()
     jm.parameters['baseDir'] = baseDir
     jm.parameters['jobBaseDir'] = "$baseDir/ciinabox-bootstrap/jenkins"
     jm.parameters['defaults'] = jobs['defaults']
-    jobTemplate = new File("$baseDir/jobs/${job.get('type','default')}.groovy").text
-    if(!job.containsKey('config')) {
-      job.put('config',[:])
+    jobTemplate = new File("$baseDir/jobs/${job.get('type', 'default')}.groovy").text
+    if (!job.containsKey('config')) {
+      job.put('config', [:])
     }
 
-    if(job.containsKey('type') && job.get('type') != 'default') {
-      jobName = job.get("name","${job['repo'].split('/')[1]}-${job['type'].split('/')[1]}")
-    } else if(job.containsKey('name')) {
+    if (job.containsKey('type') && job.get('type') != 'default') {
+      jobName = job.get("name", "${job['repo'].split('/')[1]}-${job['type'].split('/')[1]}")
+    }
+    else if (job.containsKey('name')) {
       jobName = job.get('name')
-    } else {
+    }
+    else {
       throw new IllegalArgumentException('job requires either a type or a name')
     }
     println "\nprocessing job: $jobName"


### PR DESCRIPTION
Using `-Djobfile=jobs` as environment param  is resulting in all yaml files having "jobs" (e.g. `backup-jobs.yml` `build-jobs.yml`) in their filename being processed. This is obviously not desired behaviour. I've added apache commons dependency to use their FileUtils, and now filenames are compared using equality (testing both version with or without extension provided), rather than `Stirng.contains`