### PR TITLE
Jobs file pattern, default options, Bugfix with integer parameters

### DIFF
--- a/jobs/default.groovy
+++ b/jobs/default.groovy
@@ -1,10 +1,12 @@
 import static com.base2.ciinabox.JobHelper.*
 
-if(folder != null) {
+if(folder != null && folder != "") {
   folder("$folder") {
     description("$folder")
   }
   jobName = "$folder/$jobName"
+} else {
+  jobName = "$jobName"
 }
 def job = job(jobName)
 defaults(job,jm.getParameters())

--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -40,7 +40,7 @@ class JobHelper {
         }
       } else {
         job.parameters {
-          stringParam(param.toUpperCase(),value,'')
+          stringParam(param.toUpperCase(),value.toString(),'')
         }
       }
     }

--- a/src/main/groovy/com/base2/ciinabox/JobSeeder.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobSeeder.groovy
@@ -27,7 +27,7 @@ if (!ciinabox) {
 
 def yaml = new Yaml()
 def processedJobs = false
-new FileNameFinder().getFileNames("${ciinaboxesDir.absolutePath}/${ciinabox}/jenkins/", "*jobs.yml").each {String jobsFile ->
+new FileNameFinder().getFileNames("${ciinaboxesDir.absolutePath}/${ciinabox}/jenkins/", "*.yml").each {String jobsFile ->
 
   def matchingByJobfile =
           jobFileToProcess != null &&
@@ -58,21 +58,23 @@ if (!processedJobs) {
   println "no ${j} file found for ${ciinabox} found in ${ciinaboxesDir.absolutePath}/jenkins"
 }
 
-def manageJobs(def baseDir, def username, def password, def jobs) {
+def manageJobs(def baseDir, def username, def password, def objJobFile) {
 
-  RestApiJobManagement jm = new RestApiJobManagement(jobs['jenkins_url'])
+  RestApiJobManagement jm = new RestApiJobManagement(objJobFile['jenkins_url'])
   if (username && password) {
     jm.setCredentials username, password
   }
   def jobNames = []
-  jobs['jobs'].each {job ->
+  objJobFile['jobs'].each {job ->
     jobNames << job.get('folder', '') + '/' + job.get('name')
   }
-  jobs['jobs'].each {job ->
+  objJobFile['jobs'].each {job ->
     jm.parameters.clear()
     jm.parameters['baseDir'] = baseDir
     jm.parameters['jobBaseDir'] = "$baseDir/ciinabox-bootstrap/jenkins"
-    jm.parameters['defaults'] = jobs['defaults']
+    if(objJobFile['defaults']) {
+      jm.parameters['defaults'] = objJobFile['defaults']
+    }
     jobTemplate = new File("$baseDir/jobs/${job.get('type', 'default')}.groovy").text
     if (!job.containsKey('config')) {
       job.put('config', [:])

--- a/src/main/groovy/com/base2/ciinabox/JobSeeder.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobSeeder.groovy
@@ -72,7 +72,7 @@ def manageJobs(def baseDir, def username, def password, def objJobFile) {
     jm.parameters.clear()
     jm.parameters['baseDir'] = baseDir
     jm.parameters['jobBaseDir'] = "$baseDir/ciinabox-bootstrap/jenkins"
-    if(objJobFile['defaults']) {
+    if (objJobFile['defaults']) {
       jm.parameters['defaults'] = objJobFile['defaults']
     }
     jobTemplate = new File("$baseDir/jobs/${job.get('type', 'default')}.groovy").text
@@ -89,6 +89,11 @@ def manageJobs(def baseDir, def username, def password, def objJobFile) {
     else {
       throw new IllegalArgumentException('job requires either a type or a name')
     }
+
+    if (!job['folder']) {
+      job['folder'] = ''
+    }
+
     println "\nprocessing job: $jobName"
 
     jm.parameters << job


### PR DESCRIPTION
- Bug fix: When trying to use jobs file with no 'defaults' section job provisioning will fail. With this fix it is allowed to have jobs file with no defaults section
- Renamed `jobs` variable to `objJobsFile` - presenting deserialized YAML jobs file
- Removed restriction to have job files ending with `jobs.yml`
- Allowed exclusion of `folder` element in job definition. Job would fail previously with no folder property. With this fix, job will just be provisioned in 'root' folder of Jenkins.
- Allowed integer parameters. Job provisioning would fail with  error

```
Caused by: groovy.lang.MissingMethodException: No signature of method: javaposse.jobdsl.dsl.helpers.BuildParametersContext.stringParam() is applicable for argument types: (java.lang.String, java.lang.Integer, java.lang.String) values: [RETAIN_DAILY_BACKUPS, 1, ]
```
 on following parameters

```
   parameters:
      retain_daily_backups: 30
      retain_weekly_backups: 8
      retain_monthly_backups: 12
```

With fix in `JobHelper.groovy:43` this is fixed