### PR TITLE
Feature/trigger properties file

### DIFF
--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -326,6 +326,16 @@ class JobHelper {
               if(triggerJob.containsKey('parameters')) {
                 predefinedProps(toUpperCaseKeys(triggerJob.get('parameters',[:])))
               }
+              if(triggerJob.containsKey('properties_file')){
+                def properties_file = triggerJob.get('properties_file')
+                if(properties_file instanceof Map){
+                  propertiesFile(properties_file['name'],properties_file['fail_on_missing'])
+                }else if(properties_file instanceof String){
+                  propertiesFile(properties_file)
+                } else {
+                  throw new RuntimeException("Properties file must be given as map of name/fail_on_missing keys or string with file name")
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Example of usage:

```
### Trigger other jobs with properties file set

jobs: 
 -
    name: Trigger-Job-With-Properties-File
    folder: example
    shell:
      - file: scripts/generate-properties.sh
    trigger:
      -
        job: Triggered-Job
        block: true
        properties_file:
          name: env.properties
          fail_on_missing: true
      -
        job: Triggered-Job-2
        block: true
        properties_file:
          name: env.properties
          fail_on_missing: true
```