### PR TITLE
prodvide copyArtifact job with build number option

### DIFF
--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -288,7 +288,11 @@ class JobHelper {
               flatten()
               fingerprintArtifacts()
               buildSelector {
-                latestSuccessful(true)
+                if (artifact.containsKey('build_number')) {
+                  buildNumber(artifact.get('build_number'))
+                } else {
+                  latestSuccessful(true)
+                }
               }
             }
           }
@@ -299,7 +303,11 @@ class JobHelper {
             flatten()
             fingerprintArtifacts()
             buildSelector {
-              latestSuccessful(true)
+              if (artifact.containsKey('build_number')) {
+                buildNumber(artifact.get('build_number'))
+              } else {
+                latestSuccessful(true)
+              }
             }
           }
         }


### PR DESCRIPTION
Provide build numbers in to the copy artifacts build selector as a parameter into the job

```yml
    parameters:
      linux_ami: ""
    artifacts:
      -
        job: baking-linux-ami
        build_number: ${LINUX_AMI}
        file_pattern: linux-ami-*.yml
        target_directory: config/
```

This can then be used in trigger jobs to grab the `BUILD_NUMBER` of the first job and pass through into the second as a parameter using the `TRIGGERED_BUILD_NUMBER_<project name>` parameter

![screen shot 2017-02-15 at 6 15 36 pm](https://cloud.githubusercontent.com/assets/12812004/22964169/5b7e4950-f3ab-11e6-99c6-978216d6ad5e.png)
