### PR TITLE
TriggerdBy, Extensibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,12 @@ dependencies {
     compile 'org.codehaus.groovy:groovy:2.1.3'
     compile 'org.jenkins-ci.plugins:job-dsl-core:1.41'
     compile 'org.jenkins-ci.plugins:job-dsl:1.41'
+    compile 'org.reflections:reflections:0.9.10'
+    compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.24'
+
     compile group: 'org.apache.commons', name: 'commons-io', version: '1.3.2'
+    compile group: 'javax.servlet', name: 'servlet-api', version: '2.5'
+
     testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
         exclude module: 'groovy-all'
     }

--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -1,5 +1,9 @@
 package com.base2.ciinabox
 
+import com.base2.ciinabox.ext.ICiinaboxExtension
+import com.base2.ciinabox.ext.TriggeredByExtension
+import com.base2.util.ReflectionUtils
+import javafx.scene.effect.Reflection
 import javaposse.jobdsl.dsl.Job
 
 class JobHelper {
@@ -20,6 +24,12 @@ class JobHelper {
     postTriggerJobs(job,vars.get('post_trigger',[]),vars)
     archive(job, vars.get('archive', []))
     gitPush(job, vars.get('push',[]))
+
+
+    ReflectionUtils.getTypesImplementingInterface(ICiinaboxExtension,'com.base2.ciinabox.ext').each { clazz ->
+      (clazz.newInstance() as ICiinaboxExtension).extend(job, vars)
+    }
+
   }
 
   static void labels(def job, def labels) {

--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -1,10 +1,7 @@
 package com.base2.ciinabox
 
 import com.base2.ciinabox.ext.ICiinaboxExtension
-import com.base2.ciinabox.ext.TriggeredByExtension
 import com.base2.util.ReflectionUtils
-import javafx.scene.effect.Reflection
-import javaposse.jobdsl.dsl.Job
 
 class JobHelper {
 

--- a/src/main/groovy/com/base2/ciinabox/ext/ICiinaboxExtension.groovy
+++ b/src/main/groovy/com/base2/ciinabox/ext/ICiinaboxExtension.groovy
@@ -1,0 +1,12 @@
+package com.base2.ciinabox.ext
+
+import javaposse.jobdsl.dsl.Job
+
+/**
+ * Created by nikolatosic on 9/03/2017.
+ */
+public interface ICiinaboxExtension {
+
+    void extend(Job job, def jobConfiguration)
+
+}

--- a/src/main/groovy/com/base2/ciinabox/ext/TriggeredByExtension.groovy
+++ b/src/main/groovy/com/base2/ciinabox/ext/TriggeredByExtension.groovy
@@ -1,0 +1,28 @@
+package com.base2.ciinabox.ext
+
+import com.base2.util.MapUtil
+import javaposse.jobdsl.dsl.Job
+
+/**
+ * Created by nikolatosic on 9/03/2017.
+ */
+public class TriggeredByExtension implements ICiinaboxExtension {
+
+  //available opts are 'SUCCESS', 'UNSTABLE' or 'FAILURE'.
+  private static final defaults = [
+          treshold: 'SUCCESS'
+  ]
+
+  @Override
+  void extend(Job job, Object jobConfiguration) {
+    if (jobConfiguration.get('triggeredBy')) {
+      def triggerConfiguration = jobConfiguration.get('triggeredBy')
+
+      MapUtil.extend(triggerConfiguration, defaults)
+
+      job.triggers {
+        upstream(triggerConfiguration.job, triggerConfiguration.treshold)
+      }
+    }
+  }
+}

--- a/src/main/groovy/com/base2/util/MapUtil.groovy
+++ b/src/main/groovy/com/base2/util/MapUtil.groovy
@@ -1,0 +1,24 @@
+package com.base2.util
+
+/**
+ * Created by nikolatosic on 9/03/2017.
+ */
+final class MapUtil {
+
+  /**
+   * Extends groovy map1 with values from map2. If key already exists in map1 it is NOT being overwritten
+   * @param map1
+   * @param map2
+   * @return
+   */
+  public static final extend(def map1, def map2) {
+    map2.each {k, v ->
+      if (!map1[k]) {
+        map1[k] = v
+      }
+    }
+
+  }
+
+
+}

--- a/src/main/groovy/com/base2/util/ReflectionUtils.groovy
+++ b/src/main/groovy/com/base2/util/ReflectionUtils.groovy
@@ -1,0 +1,29 @@
+package com.base2.util
+
+import org.reflections.Reflections
+import org.reflections.scanners.SubTypesScanner
+import org.reflections.scanners.TypeAnnotationsScanner
+import org.reflections.util.ClasspathHelper
+import org.reflections.util.ConfigurationBuilder
+
+/**
+ * Created by nikolatosic on 9/03/2017.
+ */
+class ReflectionUtils {
+
+  static {
+    System.setProperty('org.slf4j.simpleLogger.defaultLogLevel','ERROR')
+  }
+
+  public static Set<Class> getTypesImplementingInterface(Class<?> interfaceClazz, String packageName) {
+    Reflections reflections = new Reflections(
+            new ConfigurationBuilder()
+                    .setScanners(new SubTypesScanner(false), new TypeAnnotationsScanner())
+                    .setUrls(ClasspathHelper.forPackage(packageName))
+    );
+
+
+    reflections.getSubTypesOf(interfaceClazz);
+  }
+
+}


### PR DESCRIPTION
- Added triggered by functionality. Use to set completion of one job as trigger for other. 
Example:

```
jobs:
  -
    name: Build-Node-WxPortal
    shell:
      - file: build-app.sh
    archive:
      - ${APPLICATION}-${BUILD_NUMBER}.tar.gz
      - app/build/buildInfo.json
  -
    name: Docker-Package-Node-WxPortal
    triggeredBy:
      job: weeverapps/Build-Node-WxPortal

```

- Added Interface `ICiinaboxExtension` for dynamically adding new functionality to ciinabox-jenkins.