### PR TITLE
Feature/remote trigger

### DIFF
--- a/src/main/groovy/com/base2/ciinabox/ext/RemoteTriggerExtension.groovy
+++ b/src/main/groovy/com/base2/ciinabox/ext/RemoteTriggerExtension.groovy
@@ -1,0 +1,38 @@
+package com.base2.ciinabox.ext
+
+import javaposse.jobdsl.dsl.Job
+
+/**
+ * Created by nikolatosic on 8/05/2017.
+ */
+class RemoteTriggerExtension implements ICiinaboxExtension {
+
+//  @Override
+//  String getConfigurationKey() {
+//    'remoteTrigger'
+//  }
+//
+//  @Override
+//  Map getDefaultConfiguration() {
+//    return [:]
+//  }
+//
+//  @Override
+//  void extendDsl(Job job, Object extensionConfiguration, Object jobConfiguration) {
+//    job.configure {
+//      project ->
+//        (project / 'authToken').setValue(extensionConfiguration['token'])
+//    }
+//  }
+
+  @Override
+  void extend(Job job, Object jobConfiguration) {
+    if(jobConfiguration.get('remoteTrigger')){
+      def extensionConfiguration = jobConfiguration.get('remoteTrigger')
+      job.configure {
+        project ->
+          (project / 'authToken').setValue(extensionConfiguration['token'])
+      }
+    }
+  }
+}


### PR DESCRIPTION
Allows users to enable 

> Trigger builds remotely (e.g., from scripts)

functionality, by specifying authKey (that is Authentication Token, as it's called in Jenkins UI)

e.g

```
....
  -
    name: RemotelyStartedApplicationBuild
    folder: appBuilds
    concurrentBuild: true
    remoteTrigger:                 # Specify remote trigger build
      token: 123
    parameters:
      account: "dev"
      environment: ""
      environment_config: ""
      region: "us-east-1"
    shell:
 .....
```

