### PR TITLE
Bitbucket refactored, and added pull request builder functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,13 +307,26 @@ jenkins_url: http://localhost:8080/
      push: true                                             # Trigger build upon BB push
      cron: "* * * * *"                                      # Poll SCM for changes
      repo: nlstevenen/java-experimenting-with-java-8-features # BB repo to pull sources from
-     branch: master                                         # Which branch to build
+     branch: master                                         # Which branch to build if omitted pull request builder is configured
      repo_target_dir: app_code                              # Checkout in workspace sub-folder
      credentials: my-bb-creds                               # Credentials to use for authorization with BitBucket
+     pr_cron : "* * * * *"                                  # Pull request builder, defaults to every minute
+     commentTrigger : "test this please"                    # Pull request builder re-test comment, defaults to 'retest this please'
+     ciKey          : "jenkins"                             # CI Key for pull request builder, defaults to 'jenkins'
+     ciName         : "Jenkins"                             # CI name for pull request builder, defaults to 'Jenkins'
+     approveIfSuccess: true                                 # for pull request builder, defaults to true
+     cancelOutdatedJobs: false                              # for pull request builder, defaults to false
+     checkDestinationCommit: false                          # for pull request builder, defaults to false
+     
 ```
 
 
 ### Build Triggers
+
+### Bitbucket pull request builder
+
+If you want job to build bitbucket pull requests, just configure `bitbucket` block
+without `branch` key
 
 ### Cron
 

--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -96,8 +96,6 @@ class JobHelper {
   static void scm(def job, def vars) {
     if(vars.containsKey('git')) {
       gitSCM(job, vars.get('git'), vars)
-    } else if(vars.containsKey('bitbucket')) {
-      bitbucket(job, vars.get('bitbucket'), vars)
     } else if(vars.containsKey('branch')) {
       githubScm(job, vars.get('github',[:]), vars)
     } else if(vars.containsKey('repo')){
@@ -315,35 +313,6 @@ class JobHelper {
     }
   }
 
-  static void bitbucket(def job, def scmConf, def vars) {
-    def block = mergeWithDefaults(scmConf, vars, 'bitbucket')
-    def protocol = (block.get('protocol') == 'ssh' ? 'git@bitbucket.org:' : 'https://bitbucket.org/' )
-    if(block.get('push',false)) {
-      job.triggers{
-        bitbucketPush()
-      }
-    }
-    if(block.containsKey('cron')) {
-      job.triggers {
-        scm(block.get('cron'))
-      }
-    }
-    job.scm {
-      git {
-        remote {
-          credentials(block.get('credentials'))
-          url("${protocol}${block.get('repo')}.git")
-        }
-        branch(block.get('branch'))
-        extensions {
-          wipeOutWorkspace()
-          if(block.containsKey('repo_target_dir')) {
-            relativeTargetDirectory(block.get('repo_target_dir'))
-          }
-        }
-      }
-    }
-  }
 
   static void copyLatestSuccessfulArtifacts(def job, def artifacts, def jobNames = []) {
     artifacts.each { artifact ->

--- a/src/main/groovy/com/base2/ciinabox/ext/BitbucketExtension.groovy
+++ b/src/main/groovy/com/base2/ciinabox/ext/BitbucketExtension.groovy
@@ -1,0 +1,106 @@
+package com.base2.ciinabox.ext
+
+import javaposse.jobdsl.dsl.Job
+import org.apache.commons.lang.StringUtils
+
+/**
+ * Created by nikolatosic on 5/26/17.
+ */
+class BitbucketExtension extends ExtensionBase {
+
+
+  @Override
+  String getDefaultConfigurationAttribute() {
+    'repo'
+  }
+
+  @Override
+  String getConfigurationKey() {
+    'bitbucket'
+  }
+
+  @Override
+  Map getDefaultConfiguration() {
+    [
+            pr_cron               : '* * * * *',
+            ciKey                 : 'jenkins',
+            ciName                : 'Jenkins',
+            approveIfSuccess      : true,
+            cancelOutdatedJobs    : false,
+            checkDestinationCommit: false,
+            commentTrigger        : 'test this please',
+            push                  : false
+    ]
+  }
+
+  @Override
+  void extendDsl(Job job, Object extensionConfiguration, Object jobConfiguration) {
+    //detect whether is regular or pr job
+    def hasBranch = extensionConfiguration.containsKey('branch') && StringUtils.isNotBlank(extensionConfiguration.branch),
+        repoParts = extensionConfiguration.repo.split('/')
+    if (repoParts.size() != 2) {
+      throw new RuntimeException("Error configuring ${jobConfiguration.name}:" +
+              "\nBitbucket repo must be in \$owner/\$repo format")
+    }
+    def repoOwner = repoParts[0], repo = repoParts[1]
+
+    def protocol = (extensionConfiguration.protocol == 'ssh' ? 'git@bitbucket.org:' : 'https://bitbucket.org/')
+    //configure scm
+    job.scm {
+      git {
+        remote {
+          credentials(extensionConfiguration.credentials)
+          url("${protocol}${extensionConfiguration.repo}.git")
+        }
+        extensions {
+          wipeOutWorkspace()
+          if (extensionConfiguration.containsKey('repo_target_dir')) {
+            relativeTargetDirectory(extensionConfiguration.get('repo_target_dir'))
+          }
+        }
+        branch(hasBranch ? extensionConfiguration.branch : "*/\${sourceBranch}")
+      }
+    }
+
+    //set cron for building upon commit
+    if (extensionConfiguration.containsKey('cron')) {
+      job.triggers {
+        scm(extensionConfiguration.cron)
+      }
+    }
+
+    //set bitbucket push event
+    if(extensionConfiguration.push){
+      job.triggers{
+        bitbucketPush()
+      }
+    }
+
+    //if branch not defined
+    if (!hasBranch) {
+      job.configure { Node node ->
+        //add triggers XML node if it does not exist
+        if(node.get('triggers')==null){
+          node.appendNode('triggers')
+        }
+
+        node / 'triggers' {
+          'bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger' {
+            delegate.current.attributes = [ 'plugin': 'bitbucket-pullrequest-builder' ]
+            "spec" extensionConfiguration.pr_cron
+            cron extensionConfiguration.pr_cron
+            credentialsId extensionConfiguration.credentials
+            ciKey extensionConfiguration.ciKey
+            ciName extensionConfiguration.ciName
+            approveIfSuccess extensionConfiguration.approveIfSuccess
+            repositoryOwner  "${repoOwner}"
+            repositoryName "${repo}"
+            cancelOutdatedJobs extensionConfiguration.cancelOutdatedJobs
+            checkDestinationCommit extensionConfiguration.checkDestinationCommit
+            commentTrigger extensionConfiguration.commentTrigger
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/groovy/com/base2/ciinabox/ext/ExtensionBase.groovy
+++ b/src/main/groovy/com/base2/ciinabox/ext/ExtensionBase.groovy
@@ -17,6 +17,12 @@ public abstract class ExtensionBase implements ICiinaboxExtension {
   @Override
   void setJobConfiguration(def jobConfiguration) {
     this.jobConfiguration = jobConfiguration
+
+    //pick up defaults section from job file
+    if(this.jobConfiguration.containsKey('defaults')){
+      MapUtil.extend(this.jobConfiguration, this.jobConfiguration.defaults)
+    }
+    this.jobConfiguration.remove('defaults')
   }
 
   @Override

--- a/src/main/groovy/com/base2/util/MapUtil.groovy
+++ b/src/main/groovy/com/base2/util/MapUtil.groovy
@@ -7,17 +7,21 @@ final class MapUtil {
 
   /**
    * Extends groovy map1 with values from map2. If key already exists in map1 it is NOT being overwritten
+   * If values in both maps for same key are maps, they are recursively extended
    * @param map1
    * @param map2
    * @return
    */
-  public static final extend(def map1, def map2) {
+  static final extend(def map1, def map2) {
     map2.each {k, v ->
       if (!map1[k]) {
         map1[k] = v
+      } else {
+        if (map1[k] instanceof Map && v instanceof Map){
+          extend(map1[k],v)
+        }
       }
     }
-
   }
 
 


### PR DESCRIPTION

### Bitbucket Repository

For triggering bitbucket builds, you can either poll the SCM, or 
start the build via webhook. Both approaches can be seen in example
below

```
jenkins_url: http://localhost:8080/

 - name: BitbucketJob
   folder: dsl-doc
   bitbucket:
     push: true                                             # Trigger build upon BB push
     cron: "* * * * *"                                      # Poll SCM for changes
     repo: nlstevenen/java-experimenting-with-java-8-features # BB repo to pull sources from
     branch: master                                         # Which branch to build if omitted pull request builder is configured
     repo_target_dir: app_code                              # Checkout in workspace sub-folder
     credentials: my-bb-creds                               # Credentials to use for authorization with BitBucket
     pr_cron : "* * * * *"                                  # Pull request builder, defaults to every minute
     commentTrigger : "test this please"                    # Pull request builder re-test comment, defaults to 'retest this please'
     ciKey          : "jenkins"                             # CI Key for pull request builder, defaults to 'jenkins'
     ciName         : "Jenkins"                             # CI name for pull request builder, defaults to 'Jenkins'
     approveIfSuccess: true                                 # for pull request builder, defaults to true
     cancelOutdatedJobs: false                              # for pull request builder, defaults to false
     checkDestinationCommit: false                          # for pull request builder, defaults to false
     
```


### Build Triggers

### Bitbucket pull request builder

If you want job to build bitbucket pull requests, just configure `bitbucket` block
without `branch` key