### PR TITLE
Implemented jobsScriptCompare gradle task

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,46 @@ should be defined in `src/main/resources/plugin_limits.yml`
 satisfied. To ignore failed cnstraint checks
 use `-Dignore-version-constraints=true` option when running gradle task
 
+## Comparing local scripts with remote ones 
+
+` ./gradlew jobsScriptCompare ` task will download all scripts specified
+as execute script step on configured jenkins jobs. Report on script diff is printed to standard output.
+`jobsScriptCompare` task accepts same switches as `jenkins` task
+
+`-Dusername=jenkinsuser`
+
+`-Djob=jobToPublishOrCompare`
+
+`-Djobfile=jobFileToPublishOrCompare`
+
+`-Durl=http://override.jenkins.url`
+
+`-Dignore-version-constraints=true`
+
+output example:
+
+```
+
+processing job: Backup-EBS-Production
+Processing provided DSL script
+Script #0 identical on remote and local dsl 
+Script #1 identical on remote and local dsl 
+
+
+processing job: Backup-RDS-Production
+Processing provided DSL script
+Difference in script #0 in DSL and on remote. 
+
+
+------
+Local  L#  36:|
+ #   TODO: check whatever we are in backup window for DB instance. If so, automated backup to copy from may not be available and user should be notified
+Remote L#  36:|
+ 
+------
+
+```
+
 
 ## How to test
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     compile group: 'org.apache.commons', name: 'commons-io', version: '1.3.2'
     compile group: 'javax.servlet', name: 'servlet-api', version: '2.5'
+    compile group: 'com.googlecode.java-diff-utils', name: 'diffutils', version: '1.2'
 
     testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
         exclude module: 'groovy-all'
@@ -54,6 +55,12 @@ task jenkins(dependsOn: 'classes', type: JavaExec) {
   main = 'com.base2.ciinabox.JobSeeder'
   classpath = sourceSets.main.runtimeClasspath
   systemProperties System.getProperties()
+}
+
+task jobsScriptCompare(dependsOn: 'classes', type: JavaExec) {
+    main = 'com.base2.ciinabox.ScriptCompare'
+    classpath = sourceSets.main.runtimeClasspath
+    systemProperties System.getProperties()
 }
 
 task debugXml(dependsOn: 'classes', type: JavaExec) {

--- a/src/main/groovy/com/base2/ciinabox/ScriptCompare.groovy
+++ b/src/main/groovy/com/base2/ciinabox/ScriptCompare.groovy
@@ -1,0 +1,6 @@
+package com.base2.ciinabox
+
+System.setProperty('jobManagementClass','com.base2.rest.RestApiScriptCompare')
+def clazz = Class.forName('com.base2.ciinabox.JobSeeder')
+(clazz.newInstance() as Script).run()
+

--- a/src/main/groovy/com/base2/rest/RestApiScriptCompare.groovy
+++ b/src/main/groovy/com/base2/rest/RestApiScriptCompare.groovy
@@ -1,0 +1,151 @@
+package com.base2.rest
+
+import difflib.DiffUtils
+import difflib.Patch
+import groovyx.net.http.ContentType
+import groovyx.net.http.HttpResponseDecorator
+import groovyx.net.http.RESTClient
+import javaposse.jobdsl.dsl.*
+
+
+class RestApiScriptCompare extends MockJobManagement {
+
+  final RESTClient restClient
+
+  RestApiScriptCompare(String baseUrl) {
+    if (!baseUrl != null && !baseUrl.endsWith("/")) {
+      baseUrl += "/"
+    }
+    println("using jenkins url: ${baseUrl}")
+    restClient = new RESTClient(baseUrl)
+    restClient.ignoreSSLIssues()
+    restClient.handler.failure = { it }
+  }
+
+  void setCredentials(String username, String password) {
+    restClient.headers['Authorization'] = 'Basic ' + "$username:$password".bytes.encodeBase64()
+  }
+
+  @Override
+  String getConfig(String jobName) throws JobConfigurationNotFoundException {
+    String xml = fetchExistingXml(jobName)
+    if (!xml) {
+      throw new JobConfigurationNotFoundException(jobName)
+    }
+
+    xml
+  }
+
+  @Override
+  boolean createOrUpdateConfig(Item item, boolean ignoreExisting) throws NameNotProvidedException {
+    createOrUpdateConfig(item.name, item.xml, ignoreExisting, false)
+  }
+
+  @Override
+  void createOrUpdateView(String viewName, String config, boolean ignoreExisting) throws NameNotProvidedException, ConfigurationMissingException {
+    createOrUpdateConfig(viewName, config, ignoreExisting, true)
+  }
+
+  boolean createOrUpdateConfig(String name, String xml, boolean ignoreExisting, boolean isView) throws NameNotProvidedException {
+    boolean success
+    String status
+
+    String existingXml = fetchExistingXml(name, isView)
+    if (existingXml) {
+
+      def remoteObj = new XmlSlurper().parseText(existingXml),
+          localObj = new XmlSlurper().parseText(xml),
+          remoteScripts = [ ],
+          localScripts = [ ]
+
+
+
+      //populate script arrays
+      remoteObj.children().each {
+        if (it.name() == 'builders'){
+          it.children().each { b ->
+            if(b.name() == 'hudson.tasks.Shell'){
+              remoteScripts << b.text()
+            }
+          }
+        }
+      }
+      localObj.children().each {
+        if (it.name() == 'builders'){
+          it.children().each { b ->
+            if(b.name() == 'hudson.tasks.Shell'){
+              localScripts << b.text()
+            }
+          }
+        }
+      }
+      def max = remoteScripts.size() > localScripts.size() ? remoteScripts.size() : localScripts.size()
+
+      //compare
+      for (int i = 0; i < max; i++) {
+        if(remoteScripts.size() < i+1){
+          println "Job ${name} :: Following script not found on remote machine:\n\n${localScripts[0]}"
+          continue
+        }
+        if(localScripts.size() < i+1){
+          println "Job ${name} :: Following remote script not found in DSL :\n\n${remoteScripts[0]}"
+          continue
+        }
+
+        if(!remoteScripts[i].toString().equals(localScripts[i].toString())){
+          println "Difference in script #${i} in DSL and on remote. \n\n"
+          Patch patch = DiffUtils.diff(
+                  Arrays.asList(localScripts[i].split("\n")),
+                  Arrays.asList(remoteScripts[i].split("\n"))
+          )
+          println "------"
+          patch.getDeltas().each {
+            def sourceLine = it.original.position + 1,
+                remoteLine = it.revised.position + 1,
+                sourceText = String.join("\n",it.original.lines),
+                remoteText = String.join("\n",it.revised.lines)
+            
+            println "Local  ${String.format("L#%4s", sourceLine)}:|\n $sourceText"
+            println "Remote ${String.format("L#%4s", remoteLine)}:|\n $remoteText"
+            println "------"
+          }
+
+        } else {
+          println "Script #${i} identical on remote and local dsl "
+        }
+      }
+
+    } else {
+      println "Job ${name} does not exist on remote server, could not compare"
+    }
+
+    success
+  }
+
+  @Override
+  InputStream streamFileInWorkspace(String filePath) throws IOException {
+    new File(filePath).newInputStream()
+  }
+
+  @Override
+  String readFileInWorkspace(String filePath) throws IOException {
+    new File(filePath).text
+  }
+
+
+  private String fetchExistingXml(String name, boolean isView) {
+    HttpResponseDecorator resp = restClient.get(
+            contentType: ContentType.TEXT,
+            path: getPath(name, isView) + '/config.xml',
+            headers: [ Accept: 'application/xml' ],
+    )
+    resp?.data?.text
+  }
+
+  static String getPath(String name, boolean isView) {
+    if (name.startsWith('/')) {
+      return '/' + getPath(name[1..-1], isView)
+    }
+    isView ? "view/$name" : "job/${name.replaceAll('/', '/job/')}"
+  }
+}


### PR DESCRIPTION
## Comparing local scripts with remote ones 

` ./gradlew jobsScriptCompare ` task will download all scripts specified
as execute script step on configured jenkins jobs. Report on script diff is printed to standard output.
`jobsScriptCompare` task accepts same switches as `jenkins` task

`-Dusername=jenkinsuser`

`-Djob=jobToPublishOrCompare`

`-Djobfile=jobFileToPublishOrCompare`

`-Durl=http://override.jenkins.url`

`-Dignore-version-constraints=true`

output example:

```

processing job: Backup-EBS-Production
Processing provided DSL script
Script #0 identical on remote and local dsl 
Script #1 identical on remote and local dsl 


processing job: Backup-RDS-Production
Processing provided DSL script
Difference in script #0 in DSL and on remote. 


------
Local  L#  36:|
 #   TODO: check whatever we are in backup window for DB instance. If so, automated backup to copy from may not be available and user should be notified
Remote L#  36:|
 
------

```