### PR TITLE
Feature/bb multiscm

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,34 @@ jenkins_url: http://localhost:8080/
      
 ```
 
+#### Bitbucket pull request builder
+
+If you want job to triggered via bitbucket pull requests, just configure `bitbucket` block
+without `branch` key
+
+#### Multi-SCM for bitbucket
+
+With BitBucket SCM provider and  Multiple SCM plugin for Jenkins (https://wiki.jenkins-ci.org/display/JENKINS/Multiple+SCMs+Plugin)
+you can use multiple SCMs, just define `bitbucket` element as list. Multi-SCM does not support pull rquest builder
+or push web hooks as trigger, as it is non-deterministic which repo should be observed
+
+```yaml
+ - name: MultipleBitbucketSCMJob
+   folder: dsl-doc
+   bitbucket:                                              # You can define multiple SCMs for bitbucket, each checked in
+                                                           # in it's own repository
+      -
+        repo: atlassian/asap-java
+        branch: master
+        repo_target_dir: app_code
+      -
+        repo: atlassian/docker-atlassian-bitbucket-server
+        branch: master
+        repo_target_dir: containers
+   shell:
+     - script: "mkdir -p $HOME/.m2/repository && cd app_code && docker run --rm -v $PWD:/app -v $HOME/.m2:/var/maven/.m2 base2/maven install"    # Use docker to build application
+     - script: "cd containers && docker build -t atlassian/bitbucket . "                 # Build docker image
+```
 
 ### Storing and retrieving artifacts
 
@@ -439,11 +467,6 @@ wildcard, `-Djob=$jobName` switch won't work as expected, as all dependant jobs 
 
 ### Build Triggers
 
-### Bitbucket pull request builder
-
-If you want job to build bitbucket pull requests, just configure `bitbucket` block
-without `branch` key
-
 ### Cron
 
 To trigger builds using cron expression, use `cron` property
@@ -457,3 +480,19 @@ cronTrigger: */5 * * * *   ## Runs every 5 minutes
 
 
 ### Build Steps
+
+### Pipeline jobs
+
+To publish job using pipeline groovy file, just point to file within `pipeline` configuraiton key. 
+Also, file is relative to `defaults/scripts_dir` directory
+
+```yaml
+ - name: PipelineJob
+   folder: dsl-doc
+   parameters:
+     key1:
+      description: 'Demo params in a pipeline'
+      default: 'default key1 value'
+   pipeline:
+     file: pipelines/helloworld.groovy
+```

--- a/ciinaboxes.example/example/jenkins/dsl-reference-jobs.yml
+++ b/ciinaboxes.example/example/jenkins/dsl-reference-jobs.yml
@@ -1,6 +1,7 @@
 jenkins_url: http://localhost:8080/
 
 defaults:
+  scripts_dir: ciinaboxes.example/example
   github:
     protocol: ssh                                           # SSH or HTTP
     credentials: my-gh-creds                                # Not required for public repos, this should
@@ -100,6 +101,22 @@ jobs:
      branch: master                                         # Which branch to build
      repo_target_dir: app_code                              # Checkout in workspace sub-folder
 
+ - name: MultipleBitbucketSCMJob
+   folder: dsl-doc
+   bitbucket:                                              # You can define multiple SCMs for bitbucket, each checked in
+                                                           # in it's own repository
+      -
+        repo: atlassian/asap-java
+        branch: master
+        repo_target_dir: app_code
+      -
+        repo: atlassian/docker-atlassian-bitbucket-server
+        branch: master
+        repo_target_dir: containers
+   shell:
+     - script: "mkdir -p $HOME/.m2/repository && cd app_code && docker run --rm -v $PWD:/app -v $HOME/.m2:/var/maven/.m2 base2/maven install"    # Use docker to build application
+     - script: "cd containers && docker build -t atlassian/bitbucket . "                 # Build docker image
+
  - name: SetBuildDesciption
    folder: dsl-doc
    repo: base2Services/ciinabox                             # GitHub repo, with owner
@@ -162,3 +179,12 @@ jobs:
 
    shell:
     - script: "ls -la results*"
+
+ - name: PipelineJob
+   folder: dsl-doc
+   parameters:
+     key1:
+      description: 'Demo params in a pipeline'
+      default: 'default key1 value'
+   pipeline:
+     file: pipelines/helloworld.groovy

--- a/ciinaboxes.example/example/pipelines/helloworld.groovy
+++ b/ciinaboxes.example/example/pipelines/helloworld.groovy
@@ -1,0 +1,10 @@
+#!groovy
+stage("HelloWorld"){
+
+  node {
+    sh "Hello World!!"
+
+    sh "Value of key1 is ${env.KEY1}"
+  }
+
+}

--- a/ciinaboxes.example/example/scripts/example.sh
+++ b/ciinaboxes.example/example/scripts/example.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "example jenkins script"
+printenv

--- a/ciinaboxes.example/scripts/example.sh
+++ b/ciinaboxes.example/scripts/example.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "example jenkins script"
-printenv

--- a/src/main/groovy/com/base2/ciinabox/JobSeeder.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobSeeder.groovy
@@ -131,6 +131,7 @@ def manageJobs(def baseDir, def username, def password, def objJobFile) {
     if (objJobFile['defaults']) {
       jm.parameters['defaults'] = objJobFile['defaults']
     }
+    job.each { k, v -> if (k == 'pipeline') job['type'] = 'pipeline' }
     jobTemplate = new File("$baseDir/jobs/${job.get('type', 'default')}.groovy").text
     if (!job.containsKey('config')) {
       job.put('config', [:])

--- a/src/main/groovy/com/base2/ciinabox/ext/ExtensionBase.groovy
+++ b/src/main/groovy/com/base2/ciinabox/ext/ExtensionBase.groovy
@@ -29,11 +29,24 @@ public abstract class ExtensionBase implements ICiinaboxExtension {
   void extend(Job job) {
     if (this.jobConfiguration.get(getConfigurationKey())) {
       def extensionConfiguration = this.jobConfiguration[getConfigurationKey()]
+
       // allow simple forms for job attributes key: value
       if (extensionConfiguration.getClass().isPrimitive() || extensionConfiguration instanceof String) {
         extensionConfiguration = [ "${getDefaultConfigurationAttribute()}": extensionConfiguration ]
       }
-      MapUtil.extend(extensionConfiguration, getDefaultConfiguration())
+
+      //extend all elements if list
+      if(extensionConfiguration instanceof List){
+        extensionConfiguration.each {
+          MapUtil.extend(it,getDefaultConfiguration())
+        }
+      }
+
+      //extend if map
+      if(extensionConfiguration instanceof Map){
+          MapUtil.extend(extensionConfiguration, getDefaultConfiguration())
+      }
+
       extendDsl(job, extensionConfiguration, this.jobConfiguration)
     }
   }


### PR DESCRIPTION
# Bitbucket support for Multi SCM (requires multi scm plugin installed)

With BitBucket SCM provider and  Multiple SCM plugin for Jenkins (https://wiki.jenkins-ci.org/display/JENKINS/Multiple+SCMs+Plugin)
you can use multiple SCMs, just define `bitbucket` element as list. Multi-SCM does not support pull rquest builder
or push web hooks as trigger, as it is non-deterministic which repo should be observed

```yaml
 - name: MultipleBitbucketSCMJob
   folder: dsl-doc
   bitbucket:                                              # You can define multiple SCMs for bitbucket, each checked in
                                                           # in it's own repository
      -
        repo: atlassian/asap-java
        branch: master
        repo_target_dir: app_code
      -
        repo: atlassian/docker-atlassian-bitbucket-server
        branch: master
        repo_target_dir: containers
   shell:
     - script: "mkdir -p $HOME/.m2/repository && cd app_code && docker run --rm -v $PWD:/app -v $HOME/.m2:/var/maven/.m2 base2/maven install"    # Use docker to build application
     - script: "cd containers && docker build -t atlassian/bitbucket . "                 # Build docker image
```

# Pipeline jobs
Added documentation and reference job example for pipelines. Added automatic detection of pipeline jobs, removing need to explicitly set `type: pipeline`

# Extension base updates
If extension key (defined by `getConfigurationKey()`) is defined as List, extension of default configuration setting will be applied to each member of the list. Does not support simple types, only maps (YET)



