### PR TITLE
lock job via description (and override via cli switch)

### DIFF
--- a/src/main/groovy/com/base2/rest/RestApiJobManagement.groovy
+++ b/src/main/groovy/com/base2/rest/RestApiJobManagement.groovy
@@ -75,7 +75,7 @@ class RestApiJobManagement extends MockJobManagement {
     if (existingXml) {
       //check if job description is any of dirty markers
       def jobDescription = getJobDescription(existingXml)
-      if(__DIRTY_MARKERS.contains(jobDescription.toUpperCase())){
+      if(__DIRTY_MARKERS.any{ jobDescription.toUpperCase().contains(it) }){
         def overwrite = Boolean.getBoolean('overrideDirtyJobs')
 
         if(!overwrite){


### PR DESCRIPTION
## Lock manually updated jobs, and override them forcibly

If you want ciinabox-jenkins utility to skip some of the jobs you may have manually
updated on remote Jenkins server (but haven't updated DSL), you can mark this job as "dirty"
by setting any of following scripts as job description

- DONT UPDATE WITH CIINABOX
- DON'T UPDATE WITH CIINABOX
- DO NOT UPDATE WITH CIINABOX
- SKIP CIINABOX UPDATE
- CIINABOX SKIP
- CIINABOX SKIP UPDATE

Dirty check is performed in case-insensitive style meaning that e.g. 'ciinabox skip' will 
mark job as dirty just as good as 'CIINABOX SKIP'

However, if you want to override this behaviour of `ciinabox-jenkins` utility, you may do so
by passing system property `-DoverrideDirtyJobs=true` to gradle task


**example 1 - With dirty job skipped**

```text

$ ./gradlew jenkins -Dusername=ciinabox -Dciinabox=example -Dciinaboxes=ciinaboxes.example -Durl=http://localhost:8080 -Djob=MultipleBitbucketSCMJob -Dpassword=ciinabox
:compileJava UP-TO-DATE
:compileGroovy UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:jenkins

Loading jobs from file: /Users/username/ciinabox-jenkins/ciinaboxes.example/example/jenkins/dsl-reference-jobs.yml
using jenkins url: http://localhost:8080/
Validating plugin slack version 2.2 against constraint  >=  2.2 ... 
 [SUCCESS] 
Validating plugin ghprb version 1.37.0 against constraint  >=  1.33.2 ... 
 [SUCCESS] 
using jenkins url: http://localhost:8080/

processing job: dsl-doc/MultipleBitbucketSCMJob
Processing provided DSL script
dsl-doc - updated
dsl-doc/MultipleBitbucketSCMJob -  skipped due dirty marker don't update with ciinabox (as job description)
CIINABOX HINT: use -DoverrideDirtyJobs=true property to override job dsl-doc/MultipleBitbucketSCMJob


BUILD SUCCESSFUL

Total time: 7.347 secs
```

**example 2 - With dirty job overwritten**

```text

$ ./gradlew jenkins -Dusername=ciinabox -Dciinabox=example -Dciinaboxes=ciinaboxes.example -Durl=http://localhost:8080 -Djob=MultipleBitbucketSCMJob -Dpassword=ciinabox -DoverrideDirtyJobs=true 
:compileJava UP-TO-DATE
:compileGroovy UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:jenkins

Loading jobs from file: /Users/username/ciinabox-jenkins/ciinaboxes.example/example/jenkins/dsl-reference-jobs.yml
using jenkins url: http://localhost:8080/
Validating plugin slack version 2.2 against constraint  >=  2.2 ... 
 [SUCCESS] 
Validating plugin ghprb version 1.37.0 against constraint  >=  1.33.2 ... 
 [SUCCESS] 
using jenkins url: http://localhost:8080/

processing job: dsl-doc/MultipleBitbucketSCMJob
Processing provided DSL script
dsl-doc - updated
dsl-doc/MultipleBitbucketSCMJob - updated

BUILD SUCCESSFUL

Total time: 7.742 secs

```