### PR TITLE
Bugfix: Using boolean default parameter values with parameter descrip…

### DIFF
--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -78,7 +78,7 @@ class JobHelper {
             return
           }
           def defaultValue = value['default']
-          if (!defaultValue) {
+          if (defaultValue == null) {
             defaultValue = ''
           }
           if (defaultValue instanceof Boolean) {


### PR DESCRIPTION
Fixing following setup for parameters

```yaml
parameters:
  param_name:
    description: "Build parameter"
    default: false
```

This used to result in string parameter with empty value, instead of "checkbox" (boolean) parameter with default 'unchecked' value