### PR TITLE
JUnit Publisher support

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,3 +613,22 @@ Also, file is relative to `defaults/scripts_dir` directory
    pipeline:
      file: pipelines/helloworld.groovy
 ```
+
+### Publishing Junit results
+
+Use `junit` element to set path to published junit xml results
+
+```yaml
+ ## Publishing JUnit results
+
+ - name: TestJavaLib
+   folder: dsl-doc
+   repo: workshopforci/DemoJUnit
+   branch: master
+   shell:
+      # Execute maven tests in docker maven container
+    - script: "docker run --rm -w /src -v $PWD:/src -v $HOME/.m2:/root/.m2 maven:3.5.0-alpine mvn test"
+   junit: "target/surefire-reports/**/*.xml"
+
+   
+```

--- a/ciinaboxes.example/example/jenkins/dsl-reference-jobs.yml
+++ b/ciinaboxes.example/example/jenkins/dsl-reference-jobs.yml
@@ -200,3 +200,14 @@ jobs:
       default: 'default key1 value'
    pipeline:
      file: pipelines/helloworld.groovy
+
+ ## Publishing JUnit results
+
+ - name: TestJavaLib
+   folder: dsl-doc
+   repo: jdufner/junit
+   branch: master
+   shell:
+      # Execute maven tests in docker maven container
+    - script: "docker run --rm -w /src -v $PWD:/src -v $HOME/.m2:/root/.m2 maven:3.5.0-alpine mvn test"
+   junit: "target/surefire-reports/**/*.xml"

--- a/src/main/groovy/com/base2/ciinabox/ext/ExtensionBase.groovy
+++ b/src/main/groovy/com/base2/ciinabox/ext/ExtensionBase.groovy
@@ -32,7 +32,9 @@ public abstract class ExtensionBase implements ICiinaboxExtension {
 
       // allow simple forms for job attributes key: value
       if (extensionConfiguration.getClass().isPrimitive() || extensionConfiguration instanceof String) {
-        extensionConfiguration = [ "${getDefaultConfigurationAttribute()}": extensionConfiguration ]
+        def newExtensionConfiguration = [:]
+        newExtensionConfiguration.put(getDefaultConfigurationAttribute(),extensionConfiguration)
+        extensionConfiguration = newExtensionConfiguration
       }
 
       //extend all elements if list

--- a/src/main/groovy/com/base2/ciinabox/ext/JunitReportPublisher.groovy
+++ b/src/main/groovy/com/base2/ciinabox/ext/JunitReportPublisher.groovy
@@ -1,0 +1,33 @@
+package com.base2.ciinabox.ext
+
+import javaposse.jobdsl.dsl.Job
+
+/**
+ * Created by nikolatosic on 8/9/17.
+ */
+class JunitReportPublisher extends ExtensionBase {
+
+  @Override
+  String getDefaultConfigurationAttribute() {
+    'path'
+  }
+
+  @Override
+  String getConfigurationKey() {
+    'junit'
+  }
+
+  @Override
+  Map getDefaultConfiguration() {
+    [ 'healthScaleFactor': 1.0 ]
+  }
+
+  @Override
+  void extendDsl(Job job, Object extensionConfiguration, Object jobConfiguration) {
+    job.publishers {
+      archiveJunit(extensionConfiguration.path) {
+        healthScaleFactor(extensionConfiguration.healthScaleFactor)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Publishing Junit results

Use `junit` element to set path to published junit xml results

```yaml
 ## Publishing JUnit results

 - name: TestJavaLib
   folder: dsl-doc
   repo: workshopforci/DemoJUnit
   branch: master
   shell:
      # Execute maven tests in docker maven container
    - script: "docker run --rm -w /src -v $PWD:/src -v $HOME/.m2:/root/.m2 maven:3.5.0-alpine mvn test"
   junit: "target/surefire-reports/**/*.xml"

   
```
