### PR TITLE
ghprb workspace wipeout. wildcard matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ open http://192.168.99.100:8080/ in a browser and confirm the example job have b
 
 By default all jobs are published. 
 
-If you want to specify single job, use `-Djob=$jobname`
+If you want to specify single job, or multiple jobs matching pattern, use `-Djob=$jobname`
+E.g. `-Djob=Deploy-*` will provision all with name starting with `Deploy-`
 
 If you want to specify single job file, use `-Djobfile=$jobfile[.yml]`
 

--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -1,9 +1,7 @@
 package com.base2.ciinabox
 
 import com.base2.ciinabox.ext.ExtensionBase
-import com.base2.ciinabox.ext.ICiinaboxExtension
 import com.base2.util.ReflectionUtils
-import com.sun.org.apache.xpath.internal.operations.Bool
 
 class JobHelper {
 
@@ -101,7 +99,7 @@ class JobHelper {
     } else if (vars.containsKey('branch')) {
       githubScm(job, vars.get('github', [ : ]), vars)
     } else if (vars.containsKey('repo')) {
-      pullRequestScm(job, vars.get('github', [ : ]), vars.get('repo'), vars)
+      pullRequestGithub(job, vars.get('github', [ : ]), vars.get('repo'), vars)
     }
   }
 
@@ -254,7 +252,7 @@ class JobHelper {
     }
   }
 
-  static void pullRequestScm(def job, def scm, def repo, def vars) {
+  static void pullRequestGithub(def job, def scm, def repo, def vars) {
     def gh = mergeWithDefaults(scm, vars, 'github')
     job.scm {
       git {
@@ -265,6 +263,7 @@ class JobHelper {
         }
         branch('${sha1}')
         extensions {
+          wipeOutWorkspace()
           if(gh.containsKey('repo_target_dir')) {
             relativeTargetDirectory(gh.get('repo_target_dir'))
           }

--- a/src/main/groovy/com/base2/ciinabox/JobSeeder.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobSeeder.groovy
@@ -67,7 +67,9 @@ allYamlFileNames.each {String jobsFile ->
     //if specific job is defined
     if (jobs['jobs'] && StringUtils.isNotEmpty(jobToProcess)) {
       jobs['jobs'] = jobs['jobs'].findAll {
-        (it['name'] == null) || (it['name'].equalsIgnoreCase(jobToProcess))
+        (it['name'] == null) || (it['name'].equalsIgnoreCase(jobToProcess)) ||
+                (it['name'].matches(jobToProcess)) ||
+                (it['name'].matches(jobToProcess.replace('*','.*')))
       }
       if(jobs['jobs'].size() == 0){
         return
@@ -81,7 +83,7 @@ allYamlFileNames.each {String jobsFile ->
 }
 if (!processedJobs) {
   j = jobFileToProcess ?: 'jobs.yml'
-  println "no ${j} file found for ${ciinabox} found in ${ciinaboxesDir.absolutePath}/jenkins"
+  println "no ${j} file found for ${ciinabox} found in ${ciinaboxesDir.absolutePath}/${ciinabox}/jenkins"
 }
 
 def checkPluginVersions(config){


### PR DESCRIPTION
- Using `-Djob=` system property allows specifying wildcard character. E.g. `-Djob=Deploy-Maven-*` for matching multiple job names at once. Also, specifying any valid java regex will work, e.g. `-Djob="Process-Workspace-[A|B|C|D]" will provision following jobs
    - Process-Workspace-A
     - Process-Workspace-B
     - Process-Workspace-C
     - Process-Workspace-D
- Github pull request builder will wipe out workspace by default. 