### PR TITLE
Multi-file shell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,57 @@ cronTrigger: */5 * * * *   ## Runs every 5 minutes
 ### Build Environment
 
 
-### Build Steps
+### Shell scripts
+
+#### Inline
+
+
+```yaml
+...
+  shell:
+    - script: 'mvn clean install'
+...
+```
+
+#### From file
+
+```yaml
+...
+  shell:
+    - file: 'scripts/application/build.sh'
+...
+```
+
+#### From multiple files
+
+
+End user should use `multifile` key. In example below application secrets are being delete by first logging into secret stash store, and then deleting keys themselves.
+
+```yaml
+  - name: Delete-Application-Secrets
+    parameters:
+      account:
+        options:
+          - alpha
+          - dev
+          - prod
+        description: 'Secret stash account'
+
+      environment_name:
+        default: microservices-project
+        description: 'Name of project for which secrets are being altered'
+
+      key_name:
+        default: ''
+        description: 'Name of secret key to remove'
+
+    shell:
+      - multifile:
+         - scripts/common/secrets_storage_login.sh
+         - scripts/secretmgmt/delete.sh
+
+```
+
 
 ### Pipeline jobs
 

--- a/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
+++ b/src/main/groovy/com/base2/ciinabox/JobHelper.groovy
@@ -143,6 +143,10 @@ class JobHelper {
             script = job.jobManagement.readFileInWorkspace(scriptDir + "/" + script)
           }
         }
+        if(type == 'multifile' && value instanceof List){
+           script = ''
+           value.each { f-> script+= job.jobManagement.readFileInWorkspace(scriptDir + "/" + f)}
+        }
         job.steps {
           shell script
         }

--- a/src/main/groovy/com/base2/rest/RestApiScriptCompare.groovy
+++ b/src/main/groovy/com/base2/rest/RestApiScriptCompare.groovy
@@ -11,6 +11,7 @@ import javaposse.jobdsl.dsl.*
 class RestApiScriptCompare extends MockJobManagement {
 
   final RESTClient restClient
+  final String jenkinsUrl
 
   RestApiScriptCompare(String baseUrl) {
     if (!baseUrl != null && !baseUrl.endsWith("/")) {
@@ -20,6 +21,7 @@ class RestApiScriptCompare extends MockJobManagement {
     restClient = new RESTClient(baseUrl)
     restClient.ignoreSSLIssues()
     restClient.handler.failure = { it }
+    jenkinsUrl = baseUrl
   }
 
   void setCredentials(String username, String password) {
@@ -104,7 +106,7 @@ class RestApiScriptCompare extends MockJobManagement {
                 remoteLine = it.revised.position + 1,
                 sourceText = String.join("\n",it.original.lines),
                 remoteText = String.join("\n",it.revised.lines)
-            
+
             println "Local  ${String.format("L#%4s", sourceLine)}:|\n $sourceText"
             println "Remote ${String.format("L#%4s", remoteLine)}:|\n $remoteText"
             println "------"
@@ -139,6 +141,10 @@ class RestApiScriptCompare extends MockJobManagement {
             path: getPath(name, isView) + '/config.xml',
             headers: [ Accept: 'application/xml' ],
     )
+    if(!(resp?.data?.text) || resp.statusLine.statusCode != 200){
+      def fullUrl = "${jenkinsUrl}${getPath(name, isView)}/config.xml"
+      println "GET ${fullUrl}\nStatus: ${resp.statusLine}\nBody:${resp?.data}\n"
+    }
     resp?.data?.text
   }
 


### PR DESCRIPTION
## Change

Introduces support for publishing multiple files combined into single file for "execute shell" step. 

## Problem solved

Sometime same piece of bash code, such as logging into external systems, or assuming AWS IAM role, is being repeated in multiple scripts. This PR resolves this problem by allowing publishing of multiple files as single concatenated script. 

## Usage details

End user should use `multifile` key. In example below application secrets are being deleted by first logging into secret stash store, and then deleting keys themselves.

```yaml
  - name: Delete-Application-Secrets
    parameters:
      account:
        options:
          - alpha
          - dev
          - prod
        description: 'Secret stash account'

      environment_name:
        default: microservices-project
        description: 'Name of project for which secrets are being altered'

      key_name:
        default: ''
        description: 'Name of secret key to remove'

    shell:
      - multifile:
         - scripts/common/secrets_storage_login.sh
         - scripts/secretmgmt/delete.sh

```

