### PR TITLE
Update links to use HTTPS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ sourceSets {
 repositories {
     mavenCentral()
     jcenter()
-    maven { url 'http://repo.jenkins-ci.org/releases/' }
+    maven { url 'https://repo.jenkins-ci.org/releases/' }
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip


### PR DESCRIPTION
When I tried to use gradlew I got errors when it tried to download these files, looks like the redirect from HTTP to HTTPS breaks it, so changing it to HTTPS fixed it.